### PR TITLE
Extension of EA2563: copy fields to support default search

### DIFF
--- a/solr_confs/metadata/conf/schema.xml
+++ b/solr_confs/metadata/conf/schema.xml
@@ -386,4 +386,7 @@
     <!--  Extension of EA2563: copy fields to support organizations in general -->
     <copyField source="provider" dest="foaf_organization"/>
     <copyField source="dataProvider" dest="foaf_organization"/>
+    <!--  Extension of EA2563: copy fields to support default search -->
+    <copyField source="provider" dest="text"/>
+    <copyField source="dataProvider" dest="text"/> 
 </schema>


### PR DESCRIPTION
URIs in fields 'dataProvider' and 'provider' are copied to field 'text'