### PR TITLE
Field boosting

### DIFF
--- a/solr_confs/metadata/conf/solrconfig.xml
+++ b/solr_confs/metadata/conf/solrconfig.xml
@@ -1304,6 +1304,11 @@
       <int name="rows">10</int>
       <str name="df">text</str>
 	  <str name="q.op">AND</str>
+	  <str name="defType">edismax</str>
+	  <str name="qf">title^5 proxy_dc_creator proxy_dc_description subject text</str> <!-- replaces df -->
+	  <str name="pf">text</str>
+	  <str name="ps">2</str>
+	  <str name="tie">0.1</str>
     </lst>
     <!-- In addition to defaults, "appends" params can be specified
          to identify values which should be appended to the list of

--- a/solr_confs/metadata/conf/solrconfig.xml
+++ b/solr_confs/metadata/conf/solrconfig.xml
@@ -1306,8 +1306,6 @@
 	  <str name="q.op">AND</str>
 	  <str name="defType">edismax</str>
 	  <str name="qf">title^5 proxy_dc_creator proxy_dc_description subject text</str> <!-- replaces df -->
-	  <str name="pf">text</str>
-	  <str name="ps">2</str>
 	  <str name="tie">0.1</str>
     </lst>
     <!-- In addition to defaults, "appends" params can be specified

--- a/solr_confs/metadata/conf/solrconfig.xml
+++ b/solr_confs/metadata/conf/solrconfig.xml
@@ -1302,7 +1302,6 @@
     <lst name="defaults">
       <str name="echoParams">explicit</str>
       <int name="rows">10</int>
-      <str name="df">text</str>
 	  <str name="q.op">AND</str>
 	  <str name="defType">edismax</str>
 	  <str name="qf">title^5 proxy_dc_creator proxy_dc_description subject text</str> <!-- replaces df -->


### PR DESCRIPTION
Parser changed to edismax by default in search.
Default configuration for field boosting: those tokens in the query with no field assigned will highly boost the score (*5) when they appear in the title of the item, while its appearance in the subject, description and/or creator will slightly increase the score (tie=0.1).