### PR TITLE
Update query_aliases.xml to fix fashion query

### DIFF
--- a/solr_confs/metadata/conf/query_aliases.xml
+++ b/solr_confs/metadata/conf/query_aliases.xml
@@ -12,7 +12,7 @@
           </alias-def>
           <alias-def>
               <alias>fashion</alias>
-              <query>(foaf_organization:"http://data.europeana.eu/organization/1482250000000369861") AND NOT(proxy_dc_identifier:"01457L") AND NOT(proxy_dcterms_created:[0001 TO 1300]) OR NOT(proxy_dcterms_created:[2018 TO 9999]) OR NOT(YEAR:[2018 TO 9999])</query>
+              <query>(foaf_organization:"http://data.europeana.eu/organization/1482250000000369861") OR PROVIDER:"European Fashion Heritage Association"</query>
           </alias-def>
           <alias-def>
               <alias>industrial</alias>


### PR DESCRIPTION
This is a pull request to answer an issue highlighted by Marco Rendina from EFHA, who noted that the Fashion thematic collection does not catch all EFHA content. I have updated the query to check both foaf_organisation and the PROVIDER field for EFHA , which now results in 990.414 results. I have also removed some query syntax that was no longer relevant. 

tagging @hugomanguinhas and @marrerom 